### PR TITLE
fix: Playwright MCP server parameters

### DIFF
--- a/mcp-library.json
+++ b/mcp-library.json
@@ -1416,13 +1416,14 @@
       {
         "command": "npx",
         "args": [
+          "-y",
           "@playwright/mcp@latest",
           "--isolated",
           "--headless",
           "--browser",
           "firefox",
           "--user-agent",
-          "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/125.0.6422.112 Safari/537.36"
+          "\"Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/125.0.6422.112 Safari/537.3\""
         ]
       }
     ]


### PR DESCRIPTION
- User agent parameter lacks ", so real user agent is `Mozilla/5.0` instead of `Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/125.0.6422.112 Safari/537.36`

- Also it’s better to add `-y` parameter in case there will be any interactive questions during MCP server installation